### PR TITLE
Adjusts fuzz of dice rolls, preventing too many 1s and max's

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -14,56 +14,62 @@ export const loadRoll = (roll) => {
   // Find all dice terms in the roll
   const rolledDice = roll.terms.filter((term) => term instanceof Die);
 
-  // For each dice set inside the rolled dice (2d12) (1d6) (1d8) (5d6)
-  for (let die of rolledDice) {
+  while (diffBy !== 0) {
+    // Select a random die set from the pool.
+    const randomDie = rolledDice[Math.floor(Math.random() * rolledDice.length)];
+    // Select a random die from the set
+    const randomSubDie = randomDie.results[Math.floor(Math.random() * randomDie.results.length)];
+
     // For each dice in the set (2d12 -> 2 dice, 1d6 -> 1 die, 1d8 -> 1 die, 5d6 -> 5 dice)
-    for (let subdie of die.results) {
-      // If the difference is positive, we need to reduce the result
-      if (diffBy > 0) {
-        // Calculate the distance from the minimum result
-        let fromMin = Math.abs(1 - subdie.result);
+    //for (let subdie of randomDie.results) {
+    // If the difference is positive, we need to reduce the result
+    if (diffBy > 0) {
+      // Calculate the distance from the minimum result
+      let fromMin = Math.abs(1 - randomSubDie.result);
 
-        // If the result is already the minimum, then it can't be lowered any more.
-        if (fromMin === 0) {
-          continue;
-          // If the distance from the minimum is greater than the difference, we can reduce the result by the difference
-        } else if (fromMin > diffBy) {
-          subdie.result -= diffBy;
-          roll._total -= diffBy;
-          diffBy = 0;
-          // If the distance from the minimum is less than the difference, we reduce the result to the minimum and continue
-        } else if (fromMin <= diffBy) {
-          subdie.result = 1;
-          roll._total -= fromMin;
-          diffBy -= fromMin;
-        }
-        // If the difference is negative, we need to increase the result
-      } else if (diffBy < 0) {
-        // Calculate the distance from the maximum result
-        let fromMax = die.faces - subdie.result;
-
-        // If the result is already the maximum, then it can't be raised any more.
-        if (fromMax === 0) {
-          continue;
-          // If the distance from the maximum is greater than the absolute value of the difference, we can raise the result by the absolute value of the difference
-        } else if (fromMax > Math.abs(diffBy)) {
-          subdie.result += Math.abs(diffBy);
-          roll._total += Math.abs(diffBy);
-          diffBy = 0;
-          // If the distance from the maximum is less than the absolute value of the difference, we raise the result to the maximum and continue
-        } else if (fromMax <= Math.abs(diffBy)) {
-          subdie.result = die.faces;
-          roll._total += fromMax;
-          diffBy += fromMax;
-        }
-      } else {
-        break;
+      // If the result is already the minimum, then it can't be lowered any more.
+      if (fromMin === 0) {
+        continue;
+        // If the distance from the minimum is greater than the difference, we can reduce the result by the difference
+      } else if (fromMin > diffBy) {
+        randomSubDie.result -= diffBy;
+        roll._total -= diffBy;
+        diffBy = 0;
+        // If the distance from the minimum is less than the difference, we reduce the result to the minimum and continue
+      } else if (fromMin <= diffBy) {
+        // Reduce the result by half the distance from the minimum
+        const adjustmentAmount = Math.round(fromMin / 2);
+        randomSubDie.result -= adjustmentAmount;
+        roll._total -= adjustmentAmount;
+        diffBy -= adjustmentAmount;
       }
+      // If the difference is negative, we need to increase the result
+    } else if (diffBy < 0) {
+      // Calculate the distance from the maximum result
+      let fromMax = randomDie.faces - randomSubDie.result;
+
+      // If the result is already the maximum, then it can't be raised any more.
+      if (fromMax === 0) {
+        continue;
+        // If the distance from the maximum is greater than the absolute value of the difference, we can raise the result by the absolute value of the difference
+      } else if (fromMax > Math.abs(diffBy)) {
+        randomSubDie.result += Math.abs(diffBy);
+        roll._total += Math.abs(diffBy);
+        diffBy = 0;
+        // If the distance from the maximum is less than the absolute value of the difference, we raise the result to the maximum and continue
+      } else if (fromMax <= Math.abs(diffBy)) {
+        // Raise the result by half the distance from the maximum
+        const adjustmentAmount = Math.round(fromMax / 2);
+        randomSubDie.result += adjustmentAmount;
+        roll._total += adjustmentAmount;
+        diffBy += adjustmentAmount;
+      }
+    } else {
+      break;
     }
   }
   return roll;
 };
-
 /**
  * Localizes a string using the game's localization system.
  *

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -8,6 +8,9 @@ import {
 } from "../js/utils.js";
 // eslint-disable-next-line no-shadow
 import { jest } from "@jest/globals";
+
+const ROLL_COUNT = 50;
+
 describe("module", () => {
   /**
    * @class Die
@@ -68,6 +71,7 @@ describe("module", () => {
   // eslint-disable-next-line no-undef
   global.LoadedRoll = LoadedRoll;
 
+  // eslint-disable-next-line no-undef
   global.game = {
     i18n: {
       localize: jest.fn().mockImplementation((key) => {
@@ -366,40 +370,40 @@ describe("module", () => {
 
         roll = await roll.evaluate();
         expect(roll._total).toBe(10); // Total should be modified to match the target
-        expect(roll.terms[0].results[0].result).toBe(4); // First die result should be modified
-        expect(roll.terms[0].results[1].result).toBe(6); // Second die result should remain unchanged
       });
 
-      it("set 2d6 to 10 - 20 Times", async () => {
+      it(`set 2d6 to 10 - ${ROLL_COUNT} Times`, async () => {
         let roll = new LoadedRoll("2d6", 10);
         let term1 = new Die(6, [{ result: 6 }, { result: 6 }]);
         roll._total = 12; // Set the initial total to 12
         roll.terms = [term1];
         const rollSpy = jest.spyOn(roll, "evaluate");
 
-        for (let i = 0; i < 20; i++) {
+        const results = [];
+        for (let i = 0; i < ROLL_COUNT; i++) {
           roll = await roll.evaluate();
+          results.push(roll._total);
         }
-        expect(rollSpy).toHaveBeenCalledTimes(20);
-        expect(rollSpy).toHaveReturnedTimes(20);
-        expect(roll._total).toBe(10); // Total should be modified to match the target
-        expect(roll.terms[0].results[0].result).toBe(4); // First die result should be modified
-        expect(roll.terms[0].results[1].result).toBe(6); // Second die result should remain unchanged
+        expect(rollSpy).toHaveBeenCalledTimes(ROLL_COUNT);
+        expect(rollSpy).toHaveReturnedTimes(ROLL_COUNT);
+        // expect(roll._total).toBe(10); // Total should be modified to match the target
+        expect(new Set(results)).toEqual(new Set([10]));
       });
 
-      it("set 1d20 to 15 - 20 Times", async () => {
+      it(`set 1d20 to 15 - ${ROLL_COUNT} Times`, async () => {
         let roll = new LoadedRoll("1d20", 15);
         let term1 = new Die(20, [{ result: 20 }]);
         roll._total = 20; // Set the initial total to 12
         roll.terms = [term1];
         const rollSpy = jest.spyOn(roll, "evaluate");
-        for (let i = 0; i < 20; i++) {
+        const results = [];
+        for (let i = 0; i < ROLL_COUNT; i++) {
           roll = await roll.evaluate();
+          results.push(roll._total);
         }
-        expect(rollSpy).toHaveBeenCalledTimes(20);
-        expect(rollSpy).toHaveReturnedTimes(20);
-        expect(roll._total).toBe(15); // Total should be modified to match the target
-        expect(roll.terms[0].results[0].result).toBe(15); // First die result should be modified
+        expect(rollSpy).toHaveBeenCalledTimes(ROLL_COUNT);
+        expect(rollSpy).toHaveReturnedTimes(ROLL_COUNT);
+        expect(new Set(results)).toEqual(new Set([15]));
       });
 
       it("set 4d6(10) to 4", async () => {
@@ -410,10 +414,6 @@ describe("module", () => {
 
         roll = await roll.evaluate();
         expect(roll._total).toBe(4); // Total should remain unchanged
-        expect(roll.terms[0].results[0].result).toBe(1); // First die result should remain unchanged
-        expect(roll.terms[0].results[1].result).toBe(1); // Second die result should remain unchanged
-        expect(roll.terms[0].results[2].result).toBe(1); // Third die result should remain unchanged
-        expect(roll.terms[0].results[3].result).toBe(1); // Fourth die result should remain unchanged
       });
 
       it("set 4d6(4) to 10 from 4", async () => {
@@ -424,10 +424,6 @@ describe("module", () => {
 
         roll = await roll.evaluate();
         expect(roll._total).toBe(10); // Total should remain unchanged
-        expect(roll.terms[0].results[0].result).toBe(6); // First die result should remain unchanged
-        expect(roll.terms[0].results[1].result).toBe(2); // Second die result should remain unchanged
-        expect(roll.terms[0].results[2].result).toBe(1); // Third die result should remain unchanged
-        expect(roll.terms[0].results[3].result).toBe(1); // Fourth die result should remain unchanged
       });
 
       it("set 4d6(4) to 20 from 9", async () => {
@@ -438,10 +434,6 @@ describe("module", () => {
 
         roll = await roll.evaluate();
         expect(roll._total).toBe(20); // Total should remain unchanged
-        expect(roll.terms[0].results[0].result).toBe(6); // First die result should remain unchanged
-        expect(roll.terms[0].results[1].result).toBe(6); // Second die result should remain unchanged
-        expect(roll.terms[0].results[2].result).toBe(6); // Third die result should remain unchanged
-        expect(roll.terms[0].results[3].result).toBe(2); // Fourth die result should remain unchanged
       });
 
       it("should not modify the results if the target is already met", async () => {
@@ -457,8 +449,6 @@ describe("module", () => {
         await roll.evaluate();
 
         expect(roll._total).toBe(10); // Total should remain unchanged
-        expect(roll.terms[0].results[0].result).toBe(4); // First die result should remain unchanged
-        expect(roll.terms[0].results[1].result).toBe(6); // Second die result should remain unchanged
       });
     });
     describe("evaluateTotalVsTarget", () => {


### PR DESCRIPTION
This PR should adjust the 'fuzzing' of the rolls so that random dice are selected  and individually modified.  It does this in such a way that we get far fewer pure 1s and MAX_AMOUNT rolls on weird cases like F:10d20 (L:20/H:200) T:40

Before the result could be something like [1, 1, 1, 1, 1, 1, 1, 5, 16,12] and now it should be something like [2, 3, 13, 1, 5, 3, 6, 2, 2, 3]